### PR TITLE
Wardriving position fallback + configurable web idle timeout + best-effort multi-GNSS

### DIFF
--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -663,6 +663,35 @@ static void gpsSendNmea(const char *body) {
     _serial.flush();
 }
 
+// Best-effort: ask the receiver to search every constellation it supports
+// (GPS+GLONASS+Galileo+BeiDou) instead of whatever subset it powered up with.
+// More candidate satellites in view generally means a faster first fix,
+// especially with partial sky view (urban canyon, indoors near a window).
+//
+// Sent once, right after the NMEA stream is first confirmed alive — not
+// before, because a command sent to a receiver that has not even answered
+// yet cannot be trusted to land. Like the standby commands above, both
+// dialects are sent every time and the one that does not apply is simply
+// discarded as an unrecognised sentence: there is no reliable way to tell a
+// CASIC/AT6558-class part from a MediaTek L76-class part at runtime, and
+// guessing wrong here costs nothing.
+//
+//   PCAS (CASIC / AT6558-class)  $PCAS04,<mask>   bit0=GPS bit1=BDS
+//                                                  bit2=GLONASS bit3=Galileo
+//   PMTK (MediaTek L76-class)    $PMTK353,<GPS>,<GLONASS>,<Galileo>,<GALIL_FULL>,<BeiDou>
+//
+// Unverified against real hardware for this project — both command forms are
+// the commonly documented dialect for these chip families, but exact
+// behaviour varies by firmware revision. Worst case it is a no-op exactly
+// like an unrecognised standby command already is; it is not expected to
+// make anything worse.
+static void gpsEnableAllConstellations() {
+    gpsSendNmea("PCAS04,15");            // GPS+BDS+GLONASS+Galileo, all bits set
+    delay(20);
+    gpsSendNmea("PMTK353,1,1,1,0,1");    // GPS+GLONASS+Galileo+BeiDou
+    debugLogGps("[gps] requested multi-GNSS search (best-effort, chip dialect unknown)\n");
+}
+
 static void gpsDutySleep() {
     if (_dutyAsleep || !_enabled) return;
     // Ask for a standby slightly longer than our own timer so the module's
@@ -792,6 +821,7 @@ void gpsLoop() {
             _streamConfigLocked = true;
             _everValidStreamSeen = true;
         debugLogGps("[gps] valid NMEA stream detected at baud=%lu\n", (unsigned long)_activeBaud);
+        gpsEnableAllConstellations();
     }
 
     // Boards can occasionally latch onto a noisy UART config that yields

--- a/src/node_db.cpp
+++ b/src/node_db.cpp
@@ -1,6 +1,7 @@
 #include "node_db.h"
 #include "utf8_utils.h"
 #include "config_io.h"   // sdBegin()
+#include "gps.h"         // gpsHasFix/gpsLatI/gpsLonI for the wardriving fallback
 #include <Preferences.h>
 #include "storage.h"
 #include <nvs.h>
@@ -189,6 +190,7 @@ void NodeDB::init() {
         e->lastHeardMs  = 0;  // unknown after reboot
         e->lastPosMs    = 0;  // unknown after reboot
         e->lastPersistMs = 0;
+        e->heardLatI = 0; e->heardLonI = 0; e->hasHeardPosition = false;
     }
 
     if (staleIds) {
@@ -429,7 +431,8 @@ static void nodeCsvQuote(const char *in, char *out, size_t outLen) {
 const char *nodeCsvHeader() {
     return "lastHeardEpoch,nodeId,shortName,longName,hops,snr,latI,lonI,alt,"
            "battPct,voltage,chUtil,airUtil,tempC,humidityPct,pressureHpa,"
-           "chanIdx,favorite,hasPosition,hasTelemetry,pubKey";
+           "chanIdx,favorite,hasPosition,hasTelemetry,pubKey,"
+           "heardLatI,heardLonI,hasHeardPosition";
 }
 
 void nodeCsvFormatEntry(const NodeEntry &e, char *out, size_t outLen) {
@@ -459,7 +462,8 @@ void nodeCsvFormatEntry(const NodeEntry &e, char *out, size_t outLen) {
 
     snprintf(out, outLen,
              "%ld,!%08lx,%s,%s,%u,%.2f,%ld,%ld,%ld,"
-             "%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%d,%d,%d,%d,%s",
+             "%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%.2f,%d,%d,%d,%d,%s,"
+             "%ld,%ld,%d",
              lastHeardEpoch,
              (unsigned long)e.nodeId,
              shortQ, longQ,
@@ -471,7 +475,9 @@ void nodeCsvFormatEntry(const NodeEntry &e, char *out, size_t outLen) {
              e.favorite ? 1 : 0,
              e.hasPosition ? 1 : 0,
              e.hasTelemetry ? 1 : 0,
-             pubHex);
+             pubHex,
+             (long)e.heardLatI, (long)e.heardLonI,
+             e.hasHeardPosition ? 1 : 0);
 }
 
 // Reader half of nodeCsvQuote(). See node_db.h for the contract.
@@ -1083,6 +1089,16 @@ void NodeDB::updateFromPacket(const MeshPacket &pkt) {
     e->lastHeardMs = pkt.rxMs;
     _sortDirty = true;   // recency is a ranking key
     e->snr         = pkt.snr;
+    // Wardriving fallback (see node_db.h): overwritten on every packet so the
+    // stamp always reflects where we were the LAST time we heard this node,
+    // not the first — more useful when driving/walking a route. Only stamped
+    // while our own GPS actually has a fix; a node heard entirely indoors
+    // stays without a heard-position rather than getting a stale or bogus one.
+    if (gpsHasFix()) {
+        e->heardLatI = gpsLatI();
+        e->heardLonI = gpsLonI();
+        e->hasHeardPosition = true;
+    }
     // Routing ACK/NAK can arrive on a fallback channel and should not drive
     // future DM channel selection.
     bool isRoutingAckOrNak = (pkt.portnum == ROUTING_APP && pkt.requestId != 0);

--- a/src/node_db.h
+++ b/src/node_db.h
@@ -26,6 +26,16 @@ struct NodeEntry {
     bool     hasHops;
     uint32_t lastHeardMs;
     bool     hasPosition;
+    // Wardriving fallback: our OWN position (degrees * 1e7) at the moment this
+    // node was last heard, stamped only while our GPS has a fix. Most nodes
+    // never broadcast their own POSITION packet, which otherwise makes them
+    // useless for mapping where you actually heard them. This does not claim
+    // to be the node's real location — it is "where I was standing when I
+    // heard it", the same convention WiFi wardriving already uses for an AP's
+    // logged position. hasPosition (the node's own reported fix, if any)
+    // always takes priority over this in the CSV export.
+    int32_t  heardLatI, heardLonI;
+    bool     hasHeardPosition;
     bool     hasTelemetry;
     bool     hasDeviceTelemetry;
     bool     hasEnvironmentTelemetry;

--- a/src/web_config.cpp
+++ b/src/web_config.cpp
@@ -4341,6 +4341,39 @@ static void sendConfigPage(const char *msg = "", bool lite = false) {
                 "remembered networks, and switching between them, live on the "
                 "<b>WiFi</b> tab.</p>";
     }
+    {
+        // Web config drops the connection after this many idle minutes (no HTTP
+        // request), to stop paying the WiFi-modem-sleep-disabled power cost
+        // forever if you forget to close the page. There was previously no way
+        // to see or change this from the UI at all — it silently used the
+        // 600s/10min compiled default (see MY_WEBCFG_IDLE_S in config.h), which
+        // is easy to hit mid-session while reading rather than clicking (e.g.
+        // stepping through several settings screens one at a time). 0 = never,
+        // for anyone who would rather manage power themselves.
+        static const struct { uint32_t secs; const char *label; } kIdleOpts[] = {
+            { 300,   "5 minutes" },
+            { 600,   "10 minutes (default)" },
+            { 900,   "15 minutes" },
+            { 1800,  "30 minutes" },
+            { 3600,  "1 hour" },
+            { 0,     "Never" },
+        };
+        const uint32_t curIdle = gCfg->webCfgIdleTimeoutS;
+        html += "<label>Web Config Idle Timeout<select name='webcfg_idle_s'>";
+        for (size_t i = 0; i < sizeof(kIdleOpts) / sizeof(kIdleOpts[0]); i++) {
+            snprintf(tmp, sizeof(tmp), "<option value='%lu'%s>%s</option>",
+                     (unsigned long)kIdleOpts[i].secs,
+                     (curIdle == kIdleOpts[i].secs) ? " selected" : "",
+                     kIdleOpts[i].label);
+            html += tmp;
+        }
+        html += "</select></label>";
+        html += "<p style='font-size:.8em;color:var(--muted);margin:.2em 0 0'>"
+                "How long web config stays open with no activity before it shuts "
+                "itself down. Every page load and save counts as activity; time "
+                "spent just reading a page does not. \"Never\" keeps WiFi (and its "
+                "power draw) on until you close it from Utilities yourself.</p>";
+    }
     sectionEnd(html, lite);
     sendChunk(html);
 
@@ -7178,6 +7211,14 @@ static void handlePostSave() {
             gCfg->wifiSsid[sizeof(gCfg->wifiSsid) - 1] = '\0';
             strncpy(gCfg->wifiPass, gWifiPass, sizeof(gCfg->wifiPass) - 1);
             gCfg->wifiPass[sizeof(gCfg->wifiPass) - 1] = '\0';
+        }
+
+        if (server.hasArg("webcfg_idle_s")) {
+            gCfg->webCfgIdleTimeoutS = (uint32_t)server.arg("webcfg_idle_s").toInt();
+            // Apply to the session that is saving it, not just the next one —
+            // otherwise the very act of changing this setting could still time
+            // you out under the old value a minute later.
+            gIdleTimeoutMs = gCfg->webCfgIdleTimeoutS * 1000UL;
         }
 
         // Persist auth/connectivity keys immediately so reboot recovery doesn't


### PR DESCRIPTION
## Summary

Three changes after digging through gps.cpp, node_db.cpp/h, and web_config.cpp:

1. **Wardriving position fallback** (node_db.h/.cpp): most heard nodes never
   broadcast their own POSITION packet, so they drop out of the CSV export
   with no coordinates at all. Added `heardLatI`/`heardLonI`/`hasHeardPosition`
   fields that stamp each node with the device's OWN GPS position at the
   moment it's heard — same convention WiFi wardriving already uses for
   logging an AP's location. Only stamped while the device's own GPS has a
   fix, and never overrides a node's own reported position when it has one.

2. **Configurable Web Config Idle Timeout** (web_config.cpp): previously
   hardcoded to 600s with no UI to see or change it. Added a dropdown in the
   WiFi section (5/10/15/30/60 min, or Never), applied live to the current
   session as well as future ones.

3. **Best-effort multi-GNSS enable** (gps.cpp): the receiver is never sent
   any constellation-selection command, just runs with whatever it powers up
   with. Added a `PCAS04`/`PMTK353` multi-GNSS request (GPS+GLONASS+Galileo+
   BeiDou) sent once the NMEA stream is confirmed alive, following the same
   "send both dialects, unrecognised ones are silently discarded" pattern
   already used for the standby commands.

## Caveats

I have **not** been able to compile or test any of this on real hardware —
no dev environment set up on my end. Also ran into the build script's use of
bash `$(...)` command substitution (for the `APP_VERSION` macro) not working
under Windows `cmd.exe`, even with coreutils on PATH, which stopped me from
building locally on Windows entirely. Might be worth a README note for
Windows-without-WSL contributors.

Change #3 (GNSS constellation commands) is the least confident of the three
— command syntax is the commonly documented convention for CASIC/AT6558 and
MediaTek L76-class chips, but unverified against this project's actual
hardware.

Happy to adjust anything based on testing on your end.